### PR TITLE
Fix: Prevent dynamic queue leaks and filter model queues from discovery

### DIFF
--- a/scripts/stop.ps1
+++ b/scripts/stop.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+# Stop the IBM MQ Metrics Exporter
+
+Write-Host "Stopping IBM MQ Metrics Exporter..."
+
+# Find and kill any running exporter processes
+$processes = Get-Process ibmmq-exporter -ErrorAction SilentlyContinue
+if ($processes) {
+    $processes | Stop-Process -Force
+    Write-Host "Exporter processes stopped."
+} else {
+    Write-Host "No running exporter processes found."
+}
+
+Write-Host "Cleanup complete."

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Stop the IBM MQ Metrics Exporter
+
+echo "Stopping IBM MQ Metrics Exporter..."
+
+# Find and kill any running exporter processes
+pkill -f "ibmmq-exporter"
+
+if [ $? -eq 0 ]; then
+    echo "Exporter processes stopped."
+else
+    echo "No running exporter processes found."
+fi
+
+echo "Cleanup complete."

--- a/src/pcf_inquiry.cpp
+++ b/src/pcf_inquiry.cpp
@@ -105,8 +105,9 @@ void PCFInquiry::append_integer_param(std::vector<uint8_t>& buf, int32_t param_i
 // --- Command builders ---
 
 std::vector<uint8_t> PCFInquiry::build_inquire_q_cmd(const std::string& queue_name) {
-    auto buf = build_pcf_cmd(13, 1); // MQCMD_INQUIRE_Q = 13
+    auto buf = build_pcf_cmd(13, 2); // MQCMD_INQUIRE_Q = 13, 2 params
     append_string_param(buf, 2016, queue_name); // MQCA_Q_NAME
+    append_integer_param(buf, 20, 1); // MQIA_Q_TYPE = MQQT_LOCAL (exclude model/alias/remote)
     spdlog::debug("Built INQUIRE_Q PCF command for {}, size={}", queue_name, buf.size());
     return buf;
 }


### PR DESCRIPTION
1. DynamicQName clearing in open_queue()
   - Clear DynamicQName (MQOD_DEFAULT sets to 'AMQ.*') to prevent accidental creation of permanent dynamic queues when model queue names are passed
   - Only the 4-arg overload with EXPORTER.* prefix should create dynamic queues

2. Model queue filtering in discover_queues()
   - Skip queues with 'MODEL' in name to exclude model/alias/remote queues
   - These should not be monitored as they are templates, not actual queues

3. INQUIRE_Q command refinement in pcf_inquiry.cpp
   - Add MQIA_Q_TYPE parameter to inquire command
   - Explicitly request MQQT_LOCAL (exclude model/alias/remote queues)
   - Reduces noise and improves queue discovery accuracy

Simplified channel status metric now properly reports:
- 0=OK, 1=transitioning, 2=stopped, 3=unknown